### PR TITLE
Updating Protect for test and warning states 

### DIFF
--- a/devicetypes/tonesto7/nest-protect.src/nest-protect.groovy
+++ b/devicetypes/tonesto7/nest-protect.src/nest-protect.groovy
@@ -24,7 +24,6 @@ preferences {
    	input (description: "Setting Operational Mode allows you to test different Nest Protects states. Once saved hit refresh in Device Handler",
    	 title: "Testing Mode", displayDuringSetup: true, type: "paragraph", element: "paragraph")
               input("testMode", "enum", title: "Testing State", 
-              default: "normal",
               options: [
                 "testSmoke":"Smoke Alert",
                 "testCO": "CO Alert",

--- a/devicetypes/tonesto7/nest-protect.src/nest-protect.groovy
+++ b/devicetypes/tonesto7/nest-protect.src/nest-protect.groovy
@@ -26,7 +26,6 @@ preferences {
               input("testMode", "enum", title: "Operational Mode", 
               default: "normal",
               options: [
-                "normal":"Normal Mode",
                 "testSmoke":"Smoke Alert",
                 "testCO": "CO Alert",
                 "testWarnSmoke": "Smoke Warning",
@@ -332,11 +331,11 @@ def testingStateEvent(test) {
     	alarmState = "co-emergency"
    		sendEvent( name: 'carbonMonoxide', value: "detected", descriptionText: "CO Alarm: ${coState}", type: "physical", displayed: dispAct, isStateChange: true ) 
    	} else if (smokeState == "warning" ) {
-    	alarmState = "co-warning"
- 
+    	alarmState = "smoke-warning"
+ 		sendEvent( name: 'smoke', value: "warning", descriptionText: "Smoke Alarm: ${smokeState}", type: "physical", displayed: dispAct, isStateChange: true )    
 	} else if (coState == "warning" ) {
     	alarmState = "co-warning"
-        
+        sendEvent( name: 'carbonMonoxide', value: "warning", descriptionText: "CO Alarm: ${coState}", type: "physical", displayed: dispAct, isStateChange: true ) 
     } else {
     	alarmState = "ok"
         dispAct = !parent?.showProtAlarmStateEvts ? true : false

--- a/devicetypes/tonesto7/nest-protect.src/nest-protect.groovy
+++ b/devicetypes/tonesto7/nest-protect.src/nest-protect.groovy
@@ -23,7 +23,7 @@ preferences {
     preferences {
    	input (description: "Setting Operational Mode allows you to test different Nest Protects states. Once saved hit refresh in Device Handler",
    	 title: "Testing Mode", displayDuringSetup: true, type: "paragraph", element: "paragraph")
-              input("testMode", "enum", title: "Operational Mode", 
+              input("testMode", "enum", title: "Testing State", 
               default: "normal",
               options: [
                 "testSmoke":"Smoke Alert",


### PR DESCRIPTION
Removing "Normal" as test option to avoid confusion.

Fixed updating tiles on warning alerts
