### PR TITLE
avoid call clearHeating or clearCooling Set point too often

### DIFF
--- a/devicetypes/tonesto7/nest-thermostat.src/nest-thermostat.groovy
+++ b/devicetypes/tonesto7/nest-thermostat.src/nest-thermostat.groovy
@@ -474,10 +474,10 @@ def temperatureEvent(Double tempVal) {
 }
 
 def heatingSetpointEvent(Double tempVal) {
+    def temp = device.currentState("heatingSetpoint")?.value.toString()
     if(!state?.can_heat || (getHeatTemp() == 0) || (getHvacMode == "off")) { 
-        clearHeatingSetpoint() 
+        if(temp != "") { clearHeatingSetpoint() }
     } else {
-        def temp = device.currentState("heatingSetpoint")?.value.toString()
         def rTempVal = wantMetric() ? tempVal.round(1) : tempVal.round(0).toInteger()
         if(!temp.equals(rTempVal.toString())) {
             log.debug("UPDATED | HeatingSetpoint is (${rTempVal}) | Original Temp: (${temp})")
@@ -490,10 +490,10 @@ def heatingSetpointEvent(Double tempVal) {
 }
 
 def coolingSetpointEvent(Double tempVal) {
+    def temp = device.currentState("coolingSetpoint")?.value.toString()
     if(!state?.can_cool || (getCoolTemp() == 0) || (getHvacMode == "off")) { 
-        clearCoolingSetpoint() 
+        if(temp != "") { clearCoolingSetpoint() }
     } else {
-        def temp = device.currentState("coolingSetpoint")?.value.toString()
         def rTempVal = wantMetric() ? tempVal.round(1) : tempVal.round(0).toInteger()
         if(!temp.equals(rTempVal.toString())) {
             log.debug("UPDATED | CoolingSetpoint is (${rTempVal}) | Original Temp: (${temp})")
@@ -601,12 +601,12 @@ def isEmergencyHeat(val) {
 }
 
 def clearHeatingSetpoint() {
-    sendEvent(name:'heatingSetpoint', value: "",  descriptionText: "Clear Heating Setpoint" , display: false, displayed: true, isStateChange: true)
+    sendEvent(name:'heatingSetpoint', value: "",  descriptionText: "Clear Heating Setpoint" , display: false, displayed: true )
     state?.heating_setpoint = ""
 }
 
 def clearCoolingSetpoint() {
-    sendEvent(name:'coolingSetpoint', value: "",  descriptionText: "Clear Cooling Setpoint" , display: false, displayed: true, isStateChange: true)
+    sendEvent(name:'coolingSetpoint', value: "",  descriptionText: "Clear Cooling Setpoint" , display: false, displayed: true)
     state?.cooling_setpoint = ""
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Is the developer aware you are working on this change?
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Description of Changes

<!--- Describe your changes in detail -->
## Reason for Change

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->
## Screenshots (if appropriate):

Remove chattiness from notifications, by reducing calls and notifications of clearHeatingSetpoint and clearCoolingSetpoint
