### PR TITLE
Expose setAway and setHome commands for use by CoRE-like applications

### DIFF
--- a/devicetypes/tonesto7/nest-presence.src/nest-presence.groovy
+++ b/devicetypes/tonesto7/nest-presence.src/nest-presence.groovy
@@ -41,6 +41,8 @@ metadata {
 		command "setPresence"
 		command "refresh"
 		command "log"
+                command "setAway"
+                command "setHome"
 
 		attribute "lastConnection", "string"
 		attribute "apiStatus", "string"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description of Changes
Expose the away/home commands directly to allow for automating those states from other applications.

## Reason for Change
Was looking for an alternative to the built-in home/away automation to allow for more granular changes.  I wanted to be able to not only enable home/away, but also turn cameras on/off via CoRE.  This lets me do that from a single CoRE piston.

## How Has This Been Tested?
Tested in my own home for the past 24 hours, works as advertised.

## Screenshots (if appropriate):



