### PR TITLE
Update switch value when streaming status changes

### DIFF
--- a/devicetypes/tonesto7/nest-camera.src/nest-camera.groovy
+++ b/devicetypes/tonesto7/nest-camera.src/nest-camera.groovy
@@ -354,6 +354,7 @@ def isStreamingEvent(isStreaming) {
 	if(!isOn.equals(val)) {
 		Logger("UPDATED | Streaming Video is: (${val}) | Original State: (${isOn})")
 		sendEvent(name: "isStreaming", value: val, descriptionText: "Streaming Video is: ${val}", displayed: true, isStateChange: true, state: val)
+                sendEvent(name: "switch", value: val)
 	} else { LogAction("Streaming Video Status is: (${val}) | Original State: (${isOn})") }
 }
 
@@ -534,6 +535,7 @@ void streamingOn(manChg=false) {
 		log.trace "streamingOn..."
 		if(parent?.setCamStreaming(this, "true")) {
 			sendEvent(name: "isStreaming", value: "on", descriptionText: "Streaming Video is: on", displayed: true, isStateChange: true, state: "on")
+                        sendEvent(name: "switch", value: "on")
 			if(manChg) { incManStreamChgCnt() }
 			else { incProgStreamChgCnt() }
 		}
@@ -549,6 +551,7 @@ void streamingOff(manChg=false) {
 		log.trace "streamingOff..."
 		if(parent?.setCamStreaming(this, "false")) {
 			sendEvent(name: "isStreaming", value: "off", descriptionText: "Streaming Video is: off", displayed: true, isStateChange: true, state: "off")
+                        sendEvent(name: "switch", value: "off")
 			if(manChg) { incManStreamChgCnt() }
 			else { incProgStreamChgCnt() }
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description of Changes
This updates the camera devices type to also send switch on/off events when streaming status changes.

## Reason for Change
Wanted to tie this in to my MQTT infrastructure via the MQTT Bridge, needed to be able to keep track of status as well as control status.

## How Has This Been Tested?
Ran this in my environment, works as expected.

## Screenshots (if appropriate):



