### PR TITLE
Updated to remove negative diff in time calculation

### DIFF
--- a/smartapps/tonesto7/nst-automations.src/nst-automations.groovy
+++ b/smartapps/tonesto7/nst-automations.src/nst-automations.groovy
@@ -8338,7 +8338,7 @@ def GetTimeDiffSeconds(strtDate, stpDate=null, methName=null) {
 */
 		def start = Date.parse("E MMM dd HH:mm:ss z yyyy", strtDate).getTime()
 		def stop = Date.parse("E MMM dd HH:mm:ss z yyyy", stopVal).getTime()
-		def diff = (int) (long) (stop - start) / 1000
+		int diff = (stop - start) / 1000
 		LogTrace("[GetTimeDiffSeconds] Results for '$methName': ($diff seconds)")
 		return diff
 	} else { return null }


### PR DESCRIPTION
## Checklist:
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.

## Types of changes
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description of Changes

Use of 'def diff = (int) (long)...' causes a negative value when difference is months (23 March to 06 May). No idea why. Changing to 'int diff = ...' removes this problem

## Reason for Change
Nest mode change is constantly skipped due to incorrect result from date diff.

## How Has This Been Tested?
Tested via graph by adding extra logging and identifying the change of nest mode was constantly being skipped because of a negative value be generated by the difference calculation. The simple change proposed allows it to correctly return the difference.

## Screenshots (if appropriate):
